### PR TITLE
fix: correct spotless targets

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -99,6 +99,7 @@ dependencies {
 spotless {
     kotlin {
         ktlint()
+        target "**/*.kt"
         licenseHeaderFile "$project.rootDir/docs/license/LICENSE.header"
     }
     kotlinGradle {

--- a/app/src/androidTest/java/io/austinray/habits/ExampleInstrumentedTest.kt
+++ b/app/src/androidTest/java/io/austinray/habits/ExampleInstrumentedTest.kt
@@ -1,12 +1,26 @@
+/*
+ *  This file is part of Habit Themes.
+ * 
+ *  Habit Themes is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ * 
+ *  Habit Themes is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ * 
+ *  You should have received a copy of the GNU General Public License
+ *  along with Habit Themes. If not, see <https://www.gnu.org/licenses/>.
+ */
 package io.austinray.habits
 
-import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.ext.junit.runners.AndroidJUnit4
-
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.junit.runner.RunWith
-
-import org.junit.Assert.*
 
 /**
  * Instrumented test, which will execute on an Android device.

--- a/app/src/test/java/io/austinray/habits/ExampleUnitTest.kt
+++ b/app/src/test/java/io/austinray/habits/ExampleUnitTest.kt
@@ -1,8 +1,23 @@
+/*
+ *  This file is part of Habit Themes.
+ * 
+ *  Habit Themes is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ * 
+ *  Habit Themes is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ * 
+ *  You should have received a copy of the GNU General Public License
+ *  along with Habit Themes. If not, see <https://www.gnu.org/licenses/>.
+ */
 package io.austinray.habits
 
+import org.junit.Assert.assertEquals
 import org.junit.Test
-
-import org.junit.Assert.*
 
 /**
  * Example local unit test, which will execute on the development machine (host).


### PR DESCRIPTION
Android projects and Spotless don't behavior normally so we must define
the targets for the Kotlin files. Otherwise, Spotless doesn't run
properly. This is similar to defining tasks for JaCoCo and Android.